### PR TITLE
Add wttr plugin to fisherman

### DIFF
--- a/index
+++ b/index
@@ -472,6 +472,12 @@ Pretty, minimal, git-centric prompt
 prompt minimal
 derhuerst
 
+wttr
+https://github.com/pedrosnk/omf-wttr
+wttr integration for fish
+cli weather wttr
+pedrosnk
+
 yourls
 https://github.com/jethrokuan/fish-yourls
 CLI for YOURLS


### PR DESCRIPTION
Add a wttr plugin to fisherman that interfaces with wttr.in service and shows weather information.

Because we are all opensource.