### PR TITLE
add jhipster plugin to index

### DIFF
--- a/index
+++ b/index
@@ -519,3 +519,9 @@ https://github.com/fisherman/z
 Pure-fish z directory jumping
 z cd jump
 jethrokuan
+
+jhipster
+https://github.com/jhipster/jhipster-fisherman-plugin
+Official JHipster fisherman plugin
+jhipster java alias
+atomfrede

--- a/index
+++ b/index
@@ -244,6 +244,12 @@ Colors inspired by Jellybeans Vim palette
 color jellybeans jellyfish bright
 Limeth
 
+jhipster
+https://github.com/jhipster/jhipster-fisherman-plugin
+Official JHipster fisherman plugin
+jhipster java alias
+atomfrede
+
 joker
 https://github.com/fisherman/joker
 Powerline prompt based on the Joker
@@ -519,9 +525,3 @@ https://github.com/fisherman/z
 Pure-fish z directory jumping
 z cd jump
 jethrokuan
-
-jhipster
-https://github.com/jhipster/jhipster-fisherman-plugin
-Official JHipster fisherman plugin
-jhipster java alias
-atomfrede


### PR DESCRIPTION
This is the official JHipster Fisherman plugin. It would be cool if it can be found and installed via `fisher jhipster`. 

More Information can be found here:

https://github.com/jhipster/jhipster-fisherman-plugin
http://jhipster.github.io/fisherman/
https://github.com/atomfrede/jhipster-fisherman-plugin
