### PR TITLE
I broke CI, this fixes it

### DIFF
--- a/index
+++ b/index
@@ -118,12 +118,6 @@ Eco-minimal gray scale prompt
 minimal gray prompt
 bucaran
 
-exenv
-https://github.com/fisherman/exenv
-exenv support plugin
-elixir exenv
-daenney
-
 errno
 https://github.com/oh-my-fish/plugin-errno
 POSIX error code/string translator
@@ -135,6 +129,12 @@ https://github.com/Shadowigor/plugin-errno-grep
 Search error numbers, labels and messages
 posix error grep
 Shadowigor
+
+exenv
+https://github.com/fisherman/exenv
+exenv support plugin
+elixir exenv
+daenney
 
 expand
 https://github.com/oh-my-fish/plugin-expand


### PR DESCRIPTION
In https://github.com/fisherman/index/pull/87 I broke the ci build due to not being able to alphabet order.

![](https://imgflip.com/s/meme/Captain-Picard-Facepalm.jpg)

This fixes the problem by moving `exenv` to the correct position.