### PR TITLE
replace old url

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ All the plugins listed in this index are property of their respective owners. Fo
 [travis-link]: https://travis-ci.org/fisherman/index
 [travis-badge]: https://img.shields.io/travis/fisherman/index.svg
 [fisherman]: https://github.com/fisherman/fisherman
-[online]: http://fisherman.sh
+[online]: https://fisherman.github.io/


### PR DESCRIPTION
change old non-resolving url (fisherman.sh) to fisherman.github.io

this url is also used as repository url in the little blurb at the top of the repo, but I cannot make a pull request for that.