### PR TITLE
Add brew-completions plugin

### DIFF
--- a/index
+++ b/index
@@ -58,6 +58,12 @@ Powerline, Git prompt optimized for awesome
 prompt powerline
 bobthecow
 
+brew-completions
+https://github.com/laughedelic/brew-completions
+Improved completions for Homebrew
+input brew completion
+laughedelic
+
 cache-file
 https://github.com/nyarly/fish-cache-file
 Utility functions to cache command results into a file


### PR DESCRIPTION
I just published a plugin with improved Homebrew completions for Fish: https://github.com/laughedelic/brew-completions

(I know that I have permissions to merge anything here, but I still think it should be done by somebody else)